### PR TITLE
Try to add cachix support

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,3 +1,6 @@
+# Licensed under GNU Lesser General Public License v3 or later, see COPYING.
+# Copyright (c) 2019 Alexander Sosedkin and other contributors, see AUTHORS.
+
 with import <nixpkgs> { };
 
 let

--- a/ci.nix
+++ b/ci.nix
@@ -3,10 +3,30 @@
 
 with import <nixpkgs> { };
 
+with lib;
+
 let
   src = import ./src;
+
+  attrs = genAttrs
+    [ "aarch64" "i686" ]
+    (arch: (src { inherit arch; }) // { recurseForDerivations = true; });
+
+  isCacheable = p: !(p.preferLocalBuild or false);
+  shouldRecurseForDerivations = p: isAttrs p && p.recurseForDerivations or false;
+
+  flattenPkgs = s:
+    let
+      f = p:
+        if shouldRecurseForDerivations p then flattenPkgs p
+        else if isDerivation p then [ p ]
+        else [ ];
+    in
+      concatMap f (attrValues s);
+
+  cachePkgs = filter isCacheable (flattenPkgs attrs);
+
+  outputsOf = p: map (o: p.${o}) p.outputs;
 in
 
-lib.genAttrs
-  [ "aarch64" "i686" ]
-  (arch: (src { inherit arch; }) // { recurseForDerivations = true; })
+concatMap outputsOf cachePkgs

--- a/src/pinned-pkgs.nix
+++ b/src/pinned-pkgs.nix
@@ -12,7 +12,12 @@ let
     sha256 = "0293j9wib78n5nspywrmd9qkvcqq2vcrclrryxqnaxvj3bs1c0vj";
   };
 
-  buildPkgs = import pinnedPkgs { };
+  defaultNixpkgsArgs = {
+    config = { };
+    overlays = [ ];
+  };
+
+  buildPkgs = import pinnedPkgs defaultNixpkgsArgs;
 
   overlayJpegNoStatic = self: super: {
     inherit (buildPkgs) libjpeg;
@@ -29,14 +34,14 @@ in
 {
   inherit buildPkgs;
 
-  crossPkgs = import pinnedPkgs { inherit crossSystem; };
+  crossPkgs = import pinnedPkgs ({ inherit crossSystem; } // defaultNixpkgsArgs);
 
-  crossStaticPkgs = import pinnedPkgs {
+  crossStaticPkgs = import pinnedPkgs ({
     inherit crossSystem;
 
     crossOverlays = [
       (import "${pinnedPkgs}/pkgs/top-level/static.nix")
       overlayJpegNoStatic
     ];
-  };
+  } // defaultNixpkgsArgs);
 }

--- a/src/pkgs/default.nix
+++ b/src/pkgs/default.nix
@@ -11,7 +11,7 @@ let
 
     bootstrapZip = callPackage ./bootstrap-zip.nix { };
 
-    files = callPackage ./files { };
+    files = callPackage ./files { } // { recurseForDerivations = true; };
 
     nixDirectory = callPackage ./nix-directory.nix { };
 

--- a/src/pkgs/default.nix
+++ b/src/pkgs/default.nix
@@ -15,6 +15,8 @@ let
 
     nixDirectory = callPackage ./nix-directory.nix { };
 
+    nixInstallerSha256 = callPackage ./nix-installer-sha256.nix { };
+
     proot = callPackage ./proot.nix { };
 
     qemuAarch64Static = callPackage ./qemu-aarch64-static.nix { };

--- a/src/pkgs/nix-directory.nix
+++ b/src/pkgs/nix-directory.nix
@@ -1,23 +1,10 @@
 # Licensed under GNU Lesser General Public License v3 or later, see COPYING.
 # Copyright (c) 2019 Alexander Sosedkin and other contributors, see AUTHORS.
 
-{ arch, buildPkgs, qemuAarch64Static }:
+{ arch, buildPkgs, nixInstallerSha256, qemuAarch64Static }:
 
 let
   buildRootDirectory = "root-directory";
-  filename = "nix-2.2.2-${arch}-linux.tar.bz2.sha256";
-
-  sha256 = buildPkgs.stdenv.mkDerivation {
-    name = "nix-installer-sha256";
-
-    src = builtins.fetchurl "https://nixos.org/releases/nix/nix-2.2.2/${filename}";
-
-    unpackPhase = "true";
-
-    installPhase = ''
-      sed -e 's/\(.*\)/"\1"/' $src > $out
-    '';
-  };
 
   prootCommand = buildPkgs.lib.concatStringsSep " " [
     "${buildPkgs.proot}/bin/proot"
@@ -34,9 +21,11 @@ in
 buildPkgs.stdenv.mkDerivation {
   name = "nixDirectory";
 
+  # FIXME: find a source where sha256 never changes, nixInstallerSha256
+  # derivation is very impure..
   src = builtins.fetchurl {
     url = "https://nixos.org/releases/nix/nix-2.2.2/nix-2.2.2-${arch}-linux.tar.bz2";
-    sha256 = import sha256;
+    sha256 = import nixInstallerSha256;
   };
 
   PROOT_NO_SECCOMP = 1;  # see https://github.com/proot-me/PRoot/issues/106

--- a/src/pkgs/nix-installer-sha256.nix
+++ b/src/pkgs/nix-installer-sha256.nix
@@ -1,0 +1,16 @@
+# Licensed under GNU Lesser General Public License v3 or later, see COPYING.
+# Copyright (c) 2019 Alexander Sosedkin and other contributors, see AUTHORS.
+
+{ arch, buildPkgs }:
+
+buildPkgs.stdenv.mkDerivation {
+  name = "nix-installer-sha256";
+
+  src = builtins.fetchurl "https://nixos.org/releases/nix/nix-2.2.2/nix-2.2.2-${arch}-linux.tar.bz2.sha256";
+
+  unpackPhase = "true";
+
+  installPhase = ''
+    sed -e 's/\(.*\)/"\1"/' $src > $out
+  '';
+}


### PR DESCRIPTION
Hey, I just open a new PR for cachix support as we started to discuss in https://github.com/t184256/nix-on-droid-bootstrap/pull/13.

I tested it on my computer with following steps:

1. Build and push store paths with `nix-build ci.nix | cachix push gerschtli`
2. Remove generated gcroots:
```bash
rm result*
nix-collect-garbage
```
3. Build and fetch store paths again with `nix-build ci.nix` (cachix binary cache has to be registered locally already):
```
copying path '/nix/store/vl48fgr1v9j2lsncxlwh3ifzh2h9w70r-source' from 'https://cache.nixos.org'...
building '/nix/store/5bibwf4y9lz8c952q7q18rv4nyh35jhx-nix-installer-sha256.drv'...
unpacking sources
patching sources
configuring
no configure script, doing nothing
building
no Makefile, doing nothing
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/4mdhz0bwrak1h29qvli9f8gjz89zbgxp-nix-installer-sha256
strip is /nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/strip
patching script interpreter paths in /nix/store/4mdhz0bwrak1h29qvli9f8gjz89zbgxp-nix-installer-sha256
checking for references to /build/ in /nix/store/4mdhz0bwrak1h29qvli9f8gjz89zbgxp-nix-installer-sha256...
copying path '/nix/store/3izx77j932vi5g03725rv1qmcdjmsvjn-nixDirectory' from 'https://gerschtli.cachix.org'...
building '/nix/store/l00q0xkj8m3mk4vp0k6blszqhjhdxbaz-nix-installer-sha256.drv'...
unpacking sources
patching sources
configuring
no configure script, doing nothing
building
no Makefile, doing nothing
installing
post-installation fixup
shrinking RPATHs of ELF executables and libraries in /nix/store/y6viscr0ypik5ihhk3sksmx99z9zwdmh-nix-installer-sha256
strip is /nix/store/0y7jmqnj48ikjh37n3dl9kqw9hnn68nq-binutils-2.31.1/bin/strip
patching script interpreter paths in /nix/store/y6viscr0ypik5ihhk3sksmx99z9zwdmh-nix-installer-sha256
checking for references to /build/ in /nix/store/y6viscr0ypik5ihhk3sksmx99z9zwdmh-nix-installer-sha256...
copying path '/nix/store/zyxl5gmrhy9gql4cw7hpv05hz947aal0-nixDirectory' from 'https://gerschtli.cachix.org'...
these derivations will be built:
  /nix/store/23bwyp0gb2r21abp93nzhznllycg2vs5-login-inner.drv
  /nix/store/5i6qpb3ypr10wlg6kvi56w5syifkwcwb-nix.conf.drv
  /nix/store/7pyzz8b723q3m78606c9xap5c614gihr-nix-on-droid-install.drv
  /nix/store/cz538illxw8cr4a2khvq8gnv2yab9z0w-login.drv
  /nix/store/fflhixzb56iyi94rv0jcaqchsqq6ajbs-nix-on-droid-install.drv
  /nix/store/kby963p6gbm56w43zj4i7yxfwfznzhmb-login-inner.drv
  /nix/store/rp8yadwvsjxpan0lc11h5pc7kxsh1dh9-home.nix.default.drv
  /nix/store/wgch6p4mf35an2g1djnqa8gz9253dlsm-resolv.conf.drv
these paths will be fetched (394.33 MiB download, 2153.35 MiB unpacked):
  /nix/store/0f2lvyfq7hmp63rwbwgxy77wal3xjq69-bootstrap
  /nix/store/0xy2280dk772d64kvba3ibvcapqn5vl5-platform-tools-28.0.1
  /nix/store/1930ls2j0ay6pgk1lzf5fnj6qsfrkffx-stdenv-linux
  /nix/store/5apw5dbp9bicw4f63xcpxmijc7dk2w9c-bootstrap
  /nix/store/5rk098j6ib0jv49438i44jvl9lf68cyp-proot-termux-unstable-2019-09-05-i686-unknown-linux-android
  /nix/store/5zpgwq3xj4rnsx6n6j8himf34f5japl1-talloc-2.1.14-aarch64-unknown-linux-android
  /nix/store/65x9h7hnby3g2lrv7apj1wz2f59r5399-talloc-2.1.14-i686-unknown-linux-android
  /nix/store/82hax6bnz4gazxapiyb7lz2msv36aw46-bootstrap-zip
  /nix/store/d7s5dnx687kyigk6qdc65wdwfy0idlff-proot-termux-unstable-2019-09-05-aarch64-unknown-linux-android
  /nix/store/hx9mk75m6xb4vc1mczd48pdcmp5if95k-bionic-prebuilt
  /nix/store/j2j4jy8abzqilay1jcjqjn37cgnapszl-bootstrap-zip
  /nix/store/mhqv5dzzzpzq8p49hhxnwi6q1rs5jjhz-qemu-aarch64-static
  /nix/store/qdi2jfijw9p230bz113hmvhcz4pai69x-ndk-bundle-18.1.5063045
  /nix/store/qfg481dl6wal1ik4z7xqlgjnhjkxrkr8-bionic-prebuilt
  /nix/store/rryr4ihjnnwxr6qlj5x9p1mwyg82d34l-libc++abi-5.0.2
  /nix/store/s2f809sapq9dcbbgl1gv2yfra119s740-libc++-5.0.2
  /nix/store/wnxw0bi0jcr729akrh8sqpizdvhdnh9g-ncurses-6.1-20190112-abi5-compat
copying path '/nix/store/0f2lvyfq7hmp63rwbwgxy77wal3xjq69-bootstrap' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/5apw5dbp9bicw4f63xcpxmijc7dk2w9c-bootstrap' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/j2j4jy8abzqilay1jcjqjn37cgnapszl-bootstrap-zip' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/82hax6bnz4gazxapiyb7lz2msv36aw46-bootstrap-zip' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/rryr4ihjnnwxr6qlj5x9p1mwyg82d34l-libc++abi-5.0.2' from 'https://cache.nixos.org'...
copying path '/nix/store/wnxw0bi0jcr729akrh8sqpizdvhdnh9g-ncurses-6.1-20190112-abi5-compat' from 'https://cache.nixos.org'...
copying path '/nix/store/s2f809sapq9dcbbgl1gv2yfra119s740-libc++-5.0.2' from 'https://cache.nixos.org'...
copying path '/nix/store/0xy2280dk772d64kvba3ibvcapqn5vl5-platform-tools-28.0.1' from 'https://cache.nixos.org'...
copying path '/nix/store/d7s5dnx687kyigk6qdc65wdwfy0idlff-proot-termux-unstable-2019-09-05-aarch64-unknown-linux-android' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/5rk098j6ib0jv49438i44jvl9lf68cyp-proot-termux-unstable-2019-09-05-i686-unknown-linux-android' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/qdi2jfijw9p230bz113hmvhcz4pai69x-ndk-bundle-18.1.5063045' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/mhqv5dzzzpzq8p49hhxnwi6q1rs5jjhz-qemu-aarch64-static' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/1930ls2j0ay6pgk1lzf5fnj6qsfrkffx-stdenv-linux' from 'https://cache.nixos.org'...
building '/nix/store/rp8yadwvsjxpan0lc11h5pc7kxsh1dh9-home.nix.default.drv'...
building '/nix/store/23bwyp0gb2r21abp93nzhznllycg2vs5-login-inner.drv'...
building '/nix/store/kby963p6gbm56w43zj4i7yxfwfznzhmb-login-inner.drv'...
building '/nix/store/cz538illxw8cr4a2khvq8gnv2yab9z0w-login.drv'...
building '/nix/store/7pyzz8b723q3m78606c9xap5c614gihr-nix-on-droid-install.drv'...
building '/nix/store/fflhixzb56iyi94rv0jcaqchsqq6ajbs-nix-on-droid-install.drv'...
building '/nix/store/5i6qpb3ypr10wlg6kvi56w5syifkwcwb-nix.conf.drv'...
building '/nix/store/wgch6p4mf35an2g1djnqa8gz9253dlsm-resolv.conf.drv'...
copying path '/nix/store/hx9mk75m6xb4vc1mczd48pdcmp5if95k-bionic-prebuilt' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/qfg481dl6wal1ik4z7xqlgjnhjkxrkr8-bionic-prebuilt' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/5zpgwq3xj4rnsx6n6j8himf34f5japl1-talloc-2.1.14-aarch64-unknown-linux-android' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/65x9h7hnby3g2lrv7apj1wz2f59r5399-talloc-2.1.14-i686-unknown-linux-android' from 'https://gerschtli.cachix.org'...
/nix/store/5apw5dbp9bicw4f63xcpxmijc7dk2w9c-bootstrap
/nix/store/j2j4jy8abzqilay1jcjqjn37cgnapszl-bootstrap-zip
/nix/store/n0cwr7553h1qscs7fg3yi5ak0s0kv911-home.nix.default
/nix/store/13f9dn1dcz6v3nr0rkbg5mi7m0wr23cx-login
/nix/store/nkm4zafhqgggvmdk0fvn2y5vx1p508rd-login-inner
/nix/store/bj6wbzdf6f4aww23l1dbxalsdsgjqm61-nix.conf
/nix/store/01xidc3kn1q2dgr1hs61wbjp8lkpjg45-nix-on-droid-install
/nix/store/68c85jg2gf0kkwlxhvd6rd5rxph9d9z6-resolv.conf
/nix/store/3izx77j932vi5g03725rv1qmcdjmsvjn-nixDirectory
/nix/store/4mdhz0bwrak1h29qvli9f8gjz89zbgxp-nix-installer-sha256
/nix/store/d7s5dnx687kyigk6qdc65wdwfy0idlff-proot-termux-unstable-2019-09-05-aarch64-unknown-linux-android
/nix/store/mhqv5dzzzpzq8p49hhxnwi6q1rs5jjhz-qemu-aarch64-static
/nix/store/5zpgwq3xj4rnsx6n6j8himf34f5japl1-talloc-2.1.14-aarch64-unknown-linux-android
/nix/store/0f2lvyfq7hmp63rwbwgxy77wal3xjq69-bootstrap
/nix/store/82hax6bnz4gazxapiyb7lz2msv36aw46-bootstrap-zip
/nix/store/n0cwr7553h1qscs7fg3yi5ak0s0kv911-home.nix.default
/nix/store/13f9dn1dcz6v3nr0rkbg5mi7m0wr23cx-login
/nix/store/ym08s9gw48kx3nrsl6rxjvhrj0jsfvvm-login-inner
/nix/store/bj6wbzdf6f4aww23l1dbxalsdsgjqm61-nix.conf
/nix/store/lvi50fymscyj4m1a8h12ia9j6m8xxbak-nix-on-droid-install
/nix/store/68c85jg2gf0kkwlxhvd6rd5rxph9d9z6-resolv.conf
/nix/store/zyxl5gmrhy9gql4cw7hpv05hz947aal0-nixDirectory
/nix/store/y6viscr0ypik5ihhk3sksmx99z9zwdmh-nix-installer-sha256
/nix/store/5rk098j6ib0jv49438i44jvl9lf68cyp-proot-termux-unstable-2019-09-05-i686-unknown-linux-android
/nix/store/mhqv5dzzzpzq8p49hhxnwi6q1rs5jjhz-qemu-aarch64-static
/nix/store/65x9h7hnby3g2lrv7apj1wz2f59r5399-talloc-2.1.14-i686-unknown-linux-android
```

The fact that some derivations still get built locally is caused by two factors:
- the impurity of the `nix-installer-sha256` because it downloads the sha256 file everytime it gets built
- the derivations built via `writeText` and `writeScript`. I was not able to figure out yet why these get pushed but don't get fetched from binary cache.. As you can see the depending derivations like `bootstrap` are fetched, which means the store path is identically to the ones I already pushed. I assume that some logic in nixpkgs decides that simply rebuilding a `writeText`/`writeScript` is more efficient than downloading it. I'm going to dig further!

I tried `nix-build ci.nix` on another machine and got the following output:
```
copying path '/nix/store/vl48fgr1v9j2lsncxlwh3ifzh2h9w70r-source' from 'https://cache.nixos.org'...
copying path '/nix/store/4mdhz0bwrak1h29qvli9f8gjz89zbgxp-nix-installer-sha256' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/3izx77j932vi5g03725rv1qmcdjmsvjn-nixDirectory' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/y6viscr0ypik5ihhk3sksmx99z9zwdmh-nix-installer-sha256' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/zyxl5gmrhy9gql4cw7hpv05hz947aal0-nixDirectory' from 'https://gerschtli.cachix.org'...
these derivations will be built:                                                                         
  /nix/store/23bwyp0gb2r21abp93nzhznllycg2vs5-login-inner.drv                            
  /nix/store/5i6qpb3ypr10wlg6kvi56w5syifkwcwb-nix.conf.drv                            
  /nix/store/7pyzz8b723q3m78606c9xap5c614gihr-nix-on-droid-install.drv
  /nix/store/cz538illxw8cr4a2khvq8gnv2yab9z0w-login.drv    
  /nix/store/fflhixzb56iyi94rv0jcaqchsqq6ajbs-nix-on-droid-install.drv
  /nix/store/kby963p6gbm56w43zj4i7yxfwfznzhmb-login-inner.drv                                                                                                                                                                                                                                                                                     
  /nix/store/rp8yadwvsjxpan0lc11h5pc7kxsh1dh9-home.nix.default.drv
  /nix/store/wgch6p4mf35an2g1djnqa8gz9253dlsm-resolv.conf.drv                                                                                                                                                                                                                                                                                     
these paths will be fetched (476.73 MiB download, 2360.59 MiB unpacked):
  /nix/store/0f2lvyfq7hmp63rwbwgxy77wal3xjq69-bootstrap                                                                                                                                                                                                                                                                                           
  /nix/store/0xy2280dk772d64kvba3ibvcapqn5vl5-platform-tools-28.0.1                                                                                                                                                                                                                                                                               
  /nix/store/2iqzwckaprdrr69wy9kap23i94q0bi3w-openjdk-8u212-ga   
  /nix/store/2p5331cg724c69hcfj203ji8sj9bqv2s-polkit-0.115        
  /nix/store/5apw5dbp9bicw4f63xcpxmijc7dk2w9c-bootstrap              
  /nix/store/5rk098j6ib0jv49438i44jvl9lf68cyp-proot-termux-unstable-2019-09-05-i686-unknown-linux-android                                                                                                                                                                                                                                         
  /nix/store/5zpgwq3xj4rnsx6n6j8himf34f5japl1-talloc-2.1.14-aarch64-unknown-linux-android
  /nix/store/65x9h7hnby3g2lrv7apj1wz2f59r5399-talloc-2.1.14-i686-unknown-linux-android                                                                                                                                                                                                                                                            
  /nix/store/7x5sfjddnq51py9h7hdj3369dwnlnfkh-ORBit2-2.14.19                                                                                                                                                                                                                                                                                      
  /nix/store/82hax6bnz4gazxapiyb7lz2msv36aw46-bootstrap-zip                                                                                                                                                                                                                                                                                       
  /nix/store/bqyn2l33zzm8pgcd973g46qz534swzm3-liberation-fonts-2.00.4                                                                                                                                                                                                                                                                             
  /nix/store/d7s5dnx687kyigk6qdc65wdwfy0idlff-proot-termux-unstable-2019-09-05-aarch64-unknown-linux-android
  /nix/store/dz580wi3mhj0a217vlyj1hdih3ldiz14-dbus-glib-0.110                                              
  /nix/store/g3qsai0nz8maad51349v19yqf16rj2yv-alsa-lib-1.1.8                                               
  /nix/store/hx9mk75m6xb4vc1mczd48pdcmp5if95k-bionic-prebuilt                                              
  /nix/store/j2j4jy8abzqilay1jcjqjn37cgnapszl-bootstrap-zip                                                    
  /nix/store/jsycgv6la5nhsyb2034l7xfc5sa0ajqx-gconf-3.2.6                                                      
  /nix/store/mhqv5dzzzpzq8p49hhxnwi6q1rs5jjhz-qemu-aarch64-static                                           
  /nix/store/nqf6dmfdb7b62bdapysnf2dc4cjp7al1-openjdk-8u212-ga-jre                               
  /nix/store/qdi2jfijw9p230bz113hmvhcz4pai69x-ndk-bundle-18.1.5063045                                     
  /nix/store/qfg481dl6wal1ik4z7xqlgjnhjkxrkr8-bionic-prebuilt                                               
  /nix/store/rg93lv1yxxqw3v9hg1hkpfqr2nab5p7k-hook                                                                                                                                                                                                                                                                                                
  /nix/store/rryr4ihjnnwxr6qlj5x9p1mwyg82d34l-libc++abi-5.0.2                                                                                                                                                                                                                                                                                     
  /nix/store/s2f809sapq9dcbbgl1gv2yfra119s740-libc++-5.0.2                                                          
  /nix/store/vzmvbd94qm3kjv8m7ljbsyy8n3nygmy6-gnome-vfs-2.24.4                                                               
  /nix/store/wnxw0bi0jcr729akrh8sqpizdvhdnh9g-ncurses-6.1-20190112-abi5-compat                                    
  /nix/store/x8ly9dpv355jndl8wn3br2l50n3kz1s2-libIDL-0.8.14 
copying path '/nix/store/0f2lvyfq7hmp63rwbwgxy77wal3xjq69-bootstrap' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/g3qsai0nz8maad51349v19yqf16rj2yv-alsa-lib-1.1.8' from 'https://cache.nixos.org'...
copying path '/nix/store/5apw5dbp9bicw4f63xcpxmijc7dk2w9c-bootstrap' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/82hax6bnz4gazxapiyb7lz2msv36aw46-bootstrap-zip' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/j2j4jy8abzqilay1jcjqjn37cgnapszl-bootstrap-zip' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/dz580wi3mhj0a217vlyj1hdih3ldiz14-dbus-glib-0.110' from 'https://cache.nixos.org'...
copying path '/nix/store/rg93lv1yxxqw3v9hg1hkpfqr2nab5p7k-hook' from 'https://cache.nixos.org'...
copying path '/nix/store/x8ly9dpv355jndl8wn3br2l50n3kz1s2-libIDL-0.8.14' from 'https://cache.nixos.org'...
copying path '/nix/store/rryr4ihjnnwxr6qlj5x9p1mwyg82d34l-libc++abi-5.0.2' from 'https://cache.nixos.org'...
copying path '/nix/store/7x5sfjddnq51py9h7hdj3369dwnlnfkh-ORBit2-2.14.19' from 'https://cache.nixos.org'...                                                                                                                                                                                                                                        
copying path '/nix/store/s2f809sapq9dcbbgl1gv2yfra119s740-libc++-5.0.2' from 'https://cache.nixos.org'...                                                                                                                                                                                                                                          
copying path '/nix/store/bqyn2l33zzm8pgcd973g46qz534swzm3-liberation-fonts-2.00.4' from 'https://cache.nixos.org'...
copying path '/nix/store/wnxw0bi0jcr729akrh8sqpizdvhdnh9g-ncurses-6.1-20190112-abi5-compat' from 'https://cache.nixos.org'...
copying path '/nix/store/0xy2280dk772d64kvba3ibvcapqn5vl5-platform-tools-28.0.1' from 'https://cache.nixos.org'...
copying path '/nix/store/2p5331cg724c69hcfj203ji8sj9bqv2s-polkit-0.115' from 'https://cache.nixos.org'...
copying path '/nix/store/d7s5dnx687kyigk6qdc65wdwfy0idlff-proot-termux-unstable-2019-09-05-aarch64-unknown-linux-android' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/jsycgv6la5nhsyb2034l7xfc5sa0ajqx-gconf-3.2.6' from 'https://cache.nixos.org'...   
copying path '/nix/store/5rk098j6ib0jv49438i44jvl9lf68cyp-proot-termux-unstable-2019-09-05-i686-unknown-linux-android' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/vzmvbd94qm3kjv8m7ljbsyy8n3nygmy6-gnome-vfs-2.24.4' from 'https://cache.nixos.org'...  
copying path '/nix/store/mhqv5dzzzpzq8p49hhxnwi6q1rs5jjhz-qemu-aarch64-static' from 'https://gerschtli.cachix.org'...
copying path '/nix/store/nqf6dmfdb7b62bdapysnf2dc4cjp7al1-openjdk-8u212-ga-jre' from 'https://cache.nixos.org'...
building '/nix/store/rp8yadwvsjxpan0lc11h5pc7kxsh1dh9-home.nix.default.drv'...                   
copying path '/nix/store/2iqzwckaprdrr69wy9kap23i94q0bi3w-openjdk-8u212-ga' from 'https://cache.nixos.org'...
building '/nix/store/23bwyp0gb2r21abp93nzhznllycg2vs5-login-inner.drv'...                                   
copying path '/nix/store/qdi2jfijw9p230bz113hmvhcz4pai69x-ndk-bundle-18.1.5063045' from 'https://gerschtli.cachix.org'...
building '/nix/store/kby963p6gbm56w43zj4i7yxfwfznzhmb-login-inner.drv'...                                
copying path '/nix/store/hx9mk75m6xb4vc1mczd48pdcmp5if95k-bionic-prebuilt' from 'https://gerschtli.cachix.org'...                                                                                                                                                                                                                                  
copying path '/nix/store/qfg481dl6wal1ik4z7xqlgjnhjkxrkr8-bionic-prebuilt' from 'https://gerschtli.cachix.org'...                                                                                                                                                                                                                                  
copying path '/nix/store/65x9h7hnby3g2lrv7apj1wz2f59r5399-talloc-2.1.14-i686-unknown-linux-android' from 'https://gerschtli.cachix.org'...                                                                                                                                                                                                         
copying path '/nix/store/5zpgwq3xj4rnsx6n6j8himf34f5japl1-talloc-2.1.14-aarch64-unknown-linux-android' from 'https://gerschtli.cachix.org'...
building '/nix/store/cz538illxw8cr4a2khvq8gnv2yab9z0w-login.drv'...                                                                                                                                                                                                                                                                                
building '/nix/store/7pyzz8b723q3m78606c9xap5c614gihr-nix-on-droid-install.drv'...                      
building '/nix/store/fflhixzb56iyi94rv0jcaqchsqq6ajbs-nix-on-droid-install.drv'...                                                                           
building '/nix/store/5i6qpb3ypr10wlg6kvi56w5syifkwcwb-nix.conf.drv'...                                       
building '/nix/store/wgch6p4mf35an2g1djnqa8gz9253dlsm-resolv.conf.drv'...                                            
/nix/store/5apw5dbp9bicw4f63xcpxmijc7dk2w9c-bootstrap                                                            
/nix/store/j2j4jy8abzqilay1jcjqjn37cgnapszl-bootstrap-zip                     
/nix/store/n0cwr7553h1qscs7fg3yi5ak0s0kv911-home.nix.default                                                 
/nix/store/13f9dn1dcz6v3nr0rkbg5mi7m0wr23cx-login                        
/nix/store/nkm4zafhqgggvmdk0fvn2y5vx1p508rd-login-inner                                                                  
/nix/store/bj6wbzdf6f4aww23l1dbxalsdsgjqm61-nix.conf                     
/nix/store/01xidc3kn1q2dgr1hs61wbjp8lkpjg45-nix-on-droid-install                                                 
/nix/store/68c85jg2gf0kkwlxhvd6rd5rxph9d9z6-resolv.conf                                                          
/nix/store/3izx77j932vi5g03725rv1qmcdjmsvjn-nixDirectory                                                                                  
/nix/store/4mdhz0bwrak1h29qvli9f8gjz89zbgxp-nix-installer-sha256                                                                             
/nix/store/d7s5dnx687kyigk6qdc65wdwfy0idlff-proot-termux-unstable-2019-09-05-aarch64-unknown-linux-android
/nix/store/mhqv5dzzzpzq8p49hhxnwi6q1rs5jjhz-qemu-aarch64-static                   
/nix/store/5zpgwq3xj4rnsx6n6j8himf34f5japl1-talloc-2.1.14-aarch64-unknown-linux-android
/nix/store/0f2lvyfq7hmp63rwbwgxy77wal3xjq69-bootstrap                 
/nix/store/82hax6bnz4gazxapiyb7lz2msv36aw46-bootstrap-zip                
/nix/store/n0cwr7553h1qscs7fg3yi5ak0s0kv911-home.nix.default
/nix/store/13f9dn1dcz6v3nr0rkbg5mi7m0wr23cx-login        
/nix/store/ym08s9gw48kx3nrsl6rxjvhrj0jsfvvm-login-inner     
/nix/store/bj6wbzdf6f4aww23l1dbxalsdsgjqm61-nix.conf
/nix/store/lvi50fymscyj4m1a8h12ia9j6m8xxbak-nix-on-droid-install
/nix/store/68c85jg2gf0kkwlxhvd6rd5rxph9d9z6-resolv.conf
/nix/store/zyxl5gmrhy9gql4cw7hpv05hz947aal0-nixDirectory        
/nix/store/y6viscr0ypik5ihhk3sksmx99z9zwdmh-nix-installer-sha256
/nix/store/5rk098j6ib0jv49438i44jvl9lf68cyp-proot-termux-unstable-2019-09-05-i686-unknown-linux-android
/nix/store/mhqv5dzzzpzq8p49hhxnwi6q1rs5jjhz-qemu-aarch64-static 
/nix/store/65x9h7hnby3g2lrv7apj1wz2f59r5399-talloc-2.1.14-i686-unknown-linux-android 
```

Can you reproduce this, @t184256 ?