### PR TITLE
Manage environment variables

### DIFF
--- a/modules/build/activation.nix
+++ b/modules/build/activation.nix
@@ -111,6 +111,12 @@ in
         internal = true;
         description = "Package containing /etc files.";
       };
+
+      sessionInit = mkOption {
+        type = types.path;
+        internal = true;
+        description = "File containing session init commands like exposing environment variables.";
+      };
     };
 
   };

--- a/modules/environment/login/login-inner.nix
+++ b/modules/environment/login/login-inner.nix
@@ -17,10 +17,9 @@ writeText "login-inner" ''
   [ "$#" -gt 0 ] || echo "If nothing works, use the rescue shell and read ${config.build.installationDir}/usr/lib/login-inner"
   [ "$#" -gt 0 ] || echo "If it does not help, report bugs at https://github.com/t184256/nix-on-droid-bootstrap/issues"
 
-  export USER="${config.user.userName}"
-  export HOME="${config.user.home}"
-
-  export GC_NPROCS=1  # to prevent gc warnings of nix, see https://github.com/NixOS/nix/issues/3237
+  set +u
+  . "/nix/var/nix/profiles/per-user/$USER/profile/etc/profile.d/nix-on-droid-session-init.sh"
+  set -u
 
   ${lib.optionalString config.build.initialBuild ''
     if [ -e /etc/UNINTIALISED ]; then

--- a/modules/environment/session-init.nix
+++ b/modules/environment/session-init.nix
@@ -1,0 +1,94 @@
+# Licensed under GNU Lesser General Public License v3 or later, see COPYING.
+# Copyright (c) 2019 Alexander Sosedkin and other contributors, see AUTHORS.
+
+{ config, lib, pkgs, ... }:
+
+with lib;
+
+let
+  cfg = config.environment;
+
+  export = n: v: "export ${n}=\"${toString v}\"";
+
+  exportAll = vars: concatStringsSep "\n" (mapAttrsToList export vars);
+
+  sessionInit = pkgs.writeTextFile {
+    name = "nix-on-droid-session-init.sh";
+    destination = "/etc/profile.d/nix-on-droid-session-init.sh";
+    text = ''
+      # Only source this once.
+      [ -n "$__NOD_SESS_INIT_SOURCED" ] && return
+      export __NOD_SESS_INIT_SOURCED=1
+
+      ${exportAll cfg.sessionVariables}
+    '';
+  };
+in
+
+{
+
+  ###### interface
+
+  options = {
+
+    environment.sessionVariables = mkOption {
+      default = {};
+      type = types.attrs;
+      example = { EDITOR = "emacs"; GS_OPTIONS = "-sPAPERSIZE=a4"; };
+      description = ''
+        Environment variables to always set at login.
+        </para><para>
+        The values may refer to other environment variables using
+        POSIX.2 style variable references. For example, a variable
+        <varname>parameter</varname> may be referenced as
+        <code>$parameter</code> or <code>''${parameter}</code>. A
+        default value <literal>foo</literal> may be given as per
+        <code>''${parameter:-foo}</code> and, similarly, an alternate
+        value <literal>bar</literal> can be given as per
+        <code>''${parameter:+bar}</code>.
+        </para><para>
+        Note, these variables may be set in any order so no session
+        variable may have a runtime dependency on another session
+        variable. In particular code like
+        <programlisting language="nix">
+        environment.sessionVariables = {
+          FOO = "Hello";
+          BAR = "$FOO World!";
+        };
+        </programlisting>
+        may not work as expected. If you need to reference another
+        session variable, then do so inside Nix instead. The above
+        example then becomes
+        <programlisting language="nix">
+        environment.sessionVariables = {
+          FOO = "Hello";
+          BAR = "''${config.environment.sessionVariables.FOO} World!";
+        };
+        </programlisting>
+      '';
+    };
+
+  };
+
+
+  ###### implementation
+
+  config = {
+
+    build = { inherit sessionInit; };
+
+    environment = {
+      packages = [ sessionInit ];
+
+      sessionVariables = {
+        HOME = config.user.home;
+        USER = config.user.userName;
+
+        # To prevent gc warnings of nix, see https://github.com/NixOS/nix/issues/3237
+        GC_NPROCS = 1;
+      };
+    };
+
+  };
+
+}

--- a/modules/environment/session-init.nix
+++ b/modules/environment/session-init.nix
@@ -86,6 +86,8 @@ in
 
         # To prevent gc warnings of nix, see https://github.com/NixOS/nix/issues/3237
         GC_NPROCS = 1;
+        # Fix locale (perl apps panic without it)
+        LOCALE_ARCHIVE = "${pkgs.glibcLocales}/lib/locale/locale-archive";
       };
     };
 

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -9,6 +9,7 @@
   ./environment/links.nix
   ./environment/login
   ./environment/path.nix
+  ./environment/session-init.nix
   ./home-manager.nix
   ./user.nix
   ./version.nix

--- a/pkgs/nix-directory.nix
+++ b/pkgs/nix-directory.nix
@@ -18,7 +18,10 @@ let
   ];
 
   prootTermuxClosure = closureInfo {
-    rootPaths = [ prootTermux ];
+    rootPaths = [
+      config.build.sessionInit
+      prootTermux
+    ];
   };
 in
 


### PR DESCRIPTION
Hey,

I added `environment.sessionVariables` option and fixed https://github.com/t184256/nix-on-droid-bootstrap/issues/35.