### PR TITLE
Increase priority value to avoid conflict

### DIFF
--- a/modules/build/activation.nix
+++ b/modules/build/activation.nix
@@ -17,6 +17,7 @@ let
     pkgs.coreutils
     pkgs.diffutils
     pkgs.findutils
+    pkgs.gnugrep
     pkgs.gnused
     pkgs.ncurses          # For `tput`.
     pkgs.nix

--- a/modules/home-manager.nix
+++ b/modules/home-manager.nix
@@ -49,9 +49,19 @@ in
 
     inherit (cfg.config) assertions warnings;
 
-    build.activationAfter.homeManager = ''
-      ${cfg.config.home.activationPackage}/activate
-    '';
+    build = {
+      activationBefore = mkIf cfg.useUserPackages {
+        setPriorityHomeManagerPath = ''
+          if nix-env -q | grep '^home-manager-path$'; then
+            $DRY_RUN_CMD nix-env $VERBOSE_ARG --set-flag priority 120 home-manager-path
+          fi
+        '';
+      };
+
+      activationAfter.homeManager = ''
+        ${cfg.config.home.activationPackage}/activate
+      '';
+    };
 
     environment.packages = mkIf cfg.useUserPackages cfg.config.home.packages;
 


### PR DESCRIPTION
When enabling `home-manager.useUserPackages`, there is a conflict of duplicate package installations. Through increasing priority value this can be avoided.